### PR TITLE
fix typo in orbit@calculatehabitablezone

### DIFF
--- a/generators/orbit.js
+++ b/generators/orbit.js
@@ -64,7 +64,7 @@ function calculateHabitableZone(luminosity) {
     // Constants for inner and outer boundaries in AU based on luminosity
     // These are simplified estimates; actual calculations can be more complex
     const innerBoundary = Math.sqrt(luminosity / 1.1);
-    const outerBoundary = Math.sqrt(luminosity) / 0.53;
+    const outerBoundary = Math.sqrt(luminosity / 0.53);
 
     return {
         innerBoundary: innerBoundary,


### PR DESCRIPTION
fix a little typo in outerboundary calculation

the habitable zone is calculated multiple time but it seems the parenthesis weren't closed in the right spot on one of its occurence